### PR TITLE
Add test/e2e to ignore jest pattern

### DIFF
--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -26,7 +26,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     setupFiles: [resolve('config/polyfills.js')],
     setupTestFrameworkScriptFile: setupTestsFile,
     testPathIgnorePatterns: [
-      '<rootDir>[/\\\\](build|docs|node_modules|scripts)[/\\\\]'
+      '<rootDir>[/\\\\](build|docs|node_modules|scripts|test/e2e)[/\\\\]'
     ],
     testEnvironment: 'node',
     testURL: 'http://localhost',


### PR DESCRIPTION
Our jest tests are failing without this line, because also e2e test files are being checked.